### PR TITLE
feat: user api schema 정의

### DIFF
--- a/src/main/kotlin/gachi/chills/domain/auth/domain/model/UserContext.kt
+++ b/src/main/kotlin/gachi/chills/domain/auth/domain/model/UserContext.kt
@@ -1,0 +1,7 @@
+package gachi.chills.domain.auth.domain.model
+
+data class UserContext(
+    val id: String,
+    val name: String,
+    val email: String,
+)

--- a/src/main/kotlin/gachi/chills/domain/auth/domain/repository/UserContextHolder.kt
+++ b/src/main/kotlin/gachi/chills/domain/auth/domain/repository/UserContextHolder.kt
@@ -1,0 +1,13 @@
+package gachi.chills.domain.auth.domain.repository
+
+import gachi.chills.domain.auth.domain.model.UserContext
+
+object UserContextHolder {
+    private val holder = ThreadLocal<UserContext>()
+
+    fun get(): UserContext? = holder.get()
+
+    fun store(userContext: UserContext) = holder.set(userContext)
+
+    fun clear() = holder.remove()
+}

--- a/src/main/kotlin/gachi/chills/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/gachi/chills/domain/user/controller/UserController.kt
@@ -7,7 +7,7 @@ import gachi.chills.domain.user.controller.response.GetMyProfileResponse
 import gachi.chills.global.annotation.Auth
 import gachi.chills.global.aop.AccessControl
 import gachi.chills.global.aop.Allowed
-import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -41,16 +41,16 @@ class UserController : UserControllerDocs {
     description = "유저와 관련된 API 입니다.",
 )
 internal interface UserControllerDocs {
-    @Schema(
-        title = "내 프로필 조회",
+    @Operation(
+        summary = "내 프로필 조회",
         description = "내 프로필을 조회합니다.",
     )
     fun getMyProfile(
         @Auth userContext: UserContext,
     ): ResponseEntity<GetMyProfileResponse>
 
-    @Schema(
-        title = "내 프로필 수정",
+    @Operation(
+        summary = "내 프로필 수정",
         description = "내 프로필을 수정합니다.",
     )
     fun editMyProfile(

--- a/src/main/kotlin/gachi/chills/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/gachi/chills/domain/user/controller/UserController.kt
@@ -1,0 +1,60 @@
+package gachi.chills.domain.user.controller
+
+import gachi.chills.domain.auth.domain.model.UserContext
+import gachi.chills.domain.user.controller.request.EditMyProfileRequest
+import gachi.chills.domain.user.controller.response.EditMyProfileResponse
+import gachi.chills.domain.user.controller.response.GetMyProfileResponse
+import gachi.chills.global.annotation.Auth
+import gachi.chills.global.aop.AccessControl
+import gachi.chills.global.aop.Allowed
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/users")
+class UserController : UserControllerDocs {
+    @GetMapping("/me")
+    override fun getMyProfile(
+        @Auth userContext: UserContext,
+    ): ResponseEntity<GetMyProfileResponse> {
+        TODO("Not yet implemented")
+    }
+
+    @PatchMapping
+    @AccessControl(Allowed.AUTHENTICATED)
+    override fun editMyProfile(
+        @Auth userContext: UserContext,
+        @RequestBody request: EditMyProfileRequest,
+    ): ResponseEntity<EditMyProfileResponse> {
+        TODO("Not yet implemented")
+    }
+}
+
+@Tag(
+    name = "유저 API",
+    description = "유저와 관련된 API 입니다.",
+)
+internal interface UserControllerDocs {
+    @Schema(
+        title = "내 프로필 조회",
+        description = "내 프로필을 조회합니다.",
+    )
+    fun getMyProfile(
+        @Auth userContext: UserContext,
+    ): ResponseEntity<GetMyProfileResponse>
+
+    @Schema(
+        title = "내 프로필 수정",
+        description = "내 프로필을 수정합니다.",
+    )
+    fun editMyProfile(
+        @Auth userContext: UserContext,
+        @RequestBody request: EditMyProfileRequest,
+    ): ResponseEntity<EditMyProfileResponse>
+}

--- a/src/main/kotlin/gachi/chills/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/gachi/chills/domain/user/controller/UserController.kt
@@ -9,6 +9,7 @@ import gachi.chills.global.aop.AccessControl
 import gachi.chills.global.aop.Allowed
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -30,7 +31,7 @@ class UserController : UserControllerDocs {
     @AccessControl(Allowed.AUTHENTICATED)
     override fun editMyProfile(
         @Auth userContext: UserContext,
-        @RequestBody request: EditMyProfileRequest,
+        @RequestBody @Valid request: EditMyProfileRequest,
     ): ResponseEntity<EditMyProfileResponse> {
         TODO("Not yet implemented")
     }
@@ -55,6 +56,6 @@ internal interface UserControllerDocs {
     )
     fun editMyProfile(
         @Auth userContext: UserContext,
-        @RequestBody request: EditMyProfileRequest,
+        @RequestBody @Valid request: EditMyProfileRequest,
     ): ResponseEntity<EditMyProfileResponse>
 }

--- a/src/main/kotlin/gachi/chills/domain/user/controller/request/EditMyProfileRequest.kt
+++ b/src/main/kotlin/gachi/chills/domain/user/controller/request/EditMyProfileRequest.kt
@@ -1,0 +1,11 @@
+package gachi.chills.domain.user.controller.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class EditMyProfileRequest(
+    @field:Schema(description = "사용자 이름", example = "홍길동", required = true)
+    val name: String,
+
+    @field:Schema(description = "사용자 관심 분야 ID 목록", example = "[1, 2, 3]", required = true)
+    val topicIds: List<Long> = emptyList(),
+)

--- a/src/main/kotlin/gachi/chills/domain/user/controller/request/EditMyProfileRequest.kt
+++ b/src/main/kotlin/gachi/chills/domain/user/controller/request/EditMyProfileRequest.kt
@@ -1,8 +1,10 @@
 package gachi.chills.domain.user.controller.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 
 data class EditMyProfileRequest(
+    @Size(max = 30)
     @field:Schema(description = "사용자 이름", example = "홍길동", required = true)
     val name: String,
 

--- a/src/main/kotlin/gachi/chills/domain/user/controller/response/EditMyProfileResponse.kt
+++ b/src/main/kotlin/gachi/chills/domain/user/controller/response/EditMyProfileResponse.kt
@@ -1,0 +1,11 @@
+package gachi.chills.domain.user.controller.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class EditMyProfileResponse(
+    @field:Schema(description = "사용자 이름", example = "홍길동", required = true)
+    val name: String,
+
+    @field:Schema(description = "사용자 관심 분야 ID 목록", example = "[1, 2, 3]", required = true)
+    val topicIds: List<Long>,
+)

--- a/src/main/kotlin/gachi/chills/domain/user/controller/response/GetMyProfileResponse.kt
+++ b/src/main/kotlin/gachi/chills/domain/user/controller/response/GetMyProfileResponse.kt
@@ -1,0 +1,17 @@
+package gachi.chills.domain.user.controller.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class GetMyProfileResponse(
+    @field:Schema(description = "사용자 ID", example = "ccaa20b0e4764662b205eab16a2c3f91", required = true)
+    val id: String,
+
+    @field:Schema(description = "사용자 이름", example = "홍길동", required = true)
+    val name: String,
+
+    @field:Schema(description = "사용자 이메일", example = "example@example.com", required = true)
+    val email: String,
+
+    @field:Schema(description = "사용자 관심 분야 ID 목록", example = "[1, 2, 3]", required = true)
+    val topicIds: List<Long>,
+)

--- a/src/main/kotlin/gachi/chills/global/annotation/Auth.kt
+++ b/src/main/kotlin/gachi/chills/global/annotation/Auth.kt
@@ -1,0 +1,5 @@
+package gachi.chills.global.annotation
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Auth

--- a/src/main/kotlin/gachi/chills/global/aop/AccessControlAop.kt
+++ b/src/main/kotlin/gachi/chills/global/aop/AccessControlAop.kt
@@ -1,0 +1,23 @@
+package gachi.chills.global.aop
+
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Before
+import org.springframework.stereotype.Component
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AccessControl(vararg val allowed: Allowed)
+
+enum class Allowed {
+    PUBLIC,
+    AUTHENTICATED,
+}
+
+@Aspect
+@Component
+class AccessControlAop {
+    @Before("@annotation(gachi.chills.global.aop.AccessControl)")
+    fun checkAccessControl() {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/gachi/chills/global/config/AopConfig.kt
+++ b/src/main/kotlin/gachi/chills/global/config/AopConfig.kt
@@ -1,0 +1,8 @@
+package gachi.chills.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.EnableAspectJAutoProxy
+
+@Configuration
+@EnableAspectJAutoProxy
+class AopConfig

--- a/src/main/kotlin/gachi/chills/global/config/SwaggerConfig.kt
+++ b/src/main/kotlin/gachi/chills/global/config/SwaggerConfig.kt
@@ -1,5 +1,6 @@
 package gachi.chills.global.config
 
+import gachi.chills.global.annotation.Auth
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.info.Info
 import io.swagger.v3.oas.models.Components
@@ -7,6 +8,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springdoc.core.models.GroupedOpenApi
+import org.springdoc.core.utils.SpringDocUtils
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry
@@ -23,6 +25,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 class SwaggerConfig(
     private val swaggerClassificationProperties: SwaggerClassificationProperties,
 ) : WebMvcConfigurer {
+    init {
+        SpringDocUtils.getConfig()
+            .addAnnotationsToIgnore(
+                Auth::class.java,
+            )
+    }
+
     override fun addViewControllers(registry: ViewControllerRegistry) {
         registry.addRedirectViewController("/", "/swagger-ui.html")
     }

--- a/src/main/kotlin/gachi/chills/global/converter/TimezoneKstConverter.kt
+++ b/src/main/kotlin/gachi/chills/global/converter/TimezoneKstConverter.kt
@@ -21,7 +21,7 @@ class LocalDateTimeKstSerializer : JsonSerializer<LocalDateTime>() {
     override fun serialize(
         value: LocalDateTime,
         gen: JsonGenerator,
-        serializers: SerializerProvider
+        serializers: SerializerProvider,
     ) {
         val kstString = value.atZone(ZoneId.systemDefault())
             .withZoneSameInstant(KstFormatter.ZONE_ID)
@@ -49,7 +49,7 @@ class LocalDateKstSerializer : JsonSerializer<LocalDate>() {
     override fun serialize(
         value: LocalDate,
         gen: JsonGenerator,
-        serializers: SerializerProvider
+        serializers: SerializerProvider,
     ) {
         val kstString = value.format(KstFormatter.LOCAL_DATE_FORMATTER)
         gen.writeString(kstString)
@@ -59,7 +59,7 @@ class LocalDateKstSerializer : JsonSerializer<LocalDate>() {
 class LocalDateKstDeserializer : JsonDeserializer<LocalDate>() {
     override fun deserialize(
         p: JsonParser,
-        ctxt: DeserializationContext
+        ctxt: DeserializationContext,
     ): LocalDate {
         val text = p.text
         return LocalDate.parse(text, KstFormatter.LOCAL_DATE_FORMATTER)


### PR DESCRIPTION
## Summary

- user 관련 schema 정의
- 권한 관리를 위한 aop 인터페이스 정의
    - 이후 실제 작업 진행시 `HandlerMethodArgumentResolver`, `인증 필터`, `AccessControlAop` 구현 필요
- 로그인 API는 적용해보고 싶은 내용이 있는데 의견 부탁드립니다!
    - google oauth의 redirect_uri를 서버쪽으로 보게 해서 웹훅 형태로 인증 API를 구현하는 방식입니다
    - google oauth -> api server (GET method로 브라우저를 통한 요청) -> 인증 프로세스 -> redirect client
    - 이 때 자체 토큰 전달 방식을 쿠키를 사용하는게 제일 안전할 듯 한데 프론트 개발자분들의 의견이 필요할 것 같아 아직 스키마 정의는 스킵했습니다
    - query parameter로 전달해도 되긴 하지만 보안상의 문제로 논외로 생각했습니다
- 이외에 컨벤션 관련 내용은 언제든 말씀 부탁드립니다!